### PR TITLE
chore(docs): add info about pat with read access

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Reusable workflows for MAP terraform modules
 
 ### terratesting.yaml
 
-Workflow for running terratest code (golang)
+Workflow for running terratest code (golang).
+
+>IMPORTANT: Workflow uses organization-wide `READ_MAP_TF_MODULES` secret containing PAT with read access to `map-tf-*` repositories. This is required as some `map-tf-*` modules use sub-modules which are stored in Mattilsynet's private repositories (e.g., `map-tf-cloudrun` uses `map-tf-cloudrun-shared-lb`). Github action requires this access during `terraform init` phase to download source for external to "current" repository modules stored in private repositories. Make sure to update PAT, when new `map-tf-*` module appears and check for PAT expiration date.
 
 #### Input variables
 


### PR DESCRIPTION
**What**
`terratest.yaml` workflow requires PAT(via org-wide `READ_MAP_TF_MODULES` secret) for read access to Mattilsynet's private `map-tf-*` repositories. A few words in docs for this requirement.