### PR TITLE
oppdatert til nyeste version av wf-map-release-check

### DIFF
--- a/.github/workflows/tag_tester.yaml
+++ b/.github/workflows/tag_tester.yaml
@@ -46,7 +46,7 @@ jobs:
     needs: tag_printer
     name: sjekker version
     secrets: inherit
-    uses: Mattilsynet/wf-map-release-check/.github/workflows/Updatecheck.yaml@v1
+    uses: Mattilsynet/wf-map-release-check/.github/workflows/Updatecheck.yaml@v1.0.15
     with:
       send_to_pr: true
       self_predicted_tag: "${{ needs.tag_printer.outputs.version_tag }}"


### PR DESCRIPTION
vi bruker en gammal version av wf-map-release-check som gjør det at den ser i alle filer og ikke bare i .tf filer